### PR TITLE
Raise ADC3 Volume (Voicerecording microphone gain)

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -1538,7 +1538,7 @@
         <ctl name="DEC4 MUX" value="ADC3" />
         <ctl name="DEC4 Volume" value="84" />
         <ctl name="IIR1 INP1 MUX" value="DEC4" />
-       <ctl name="ADC3 Volume" value="13" />
+       <ctl name="ADC3 Volume" value="19" />
     </path>
 
 	<path name="adc4">


### PR DESCRIPTION
Recording volume is very low on OnePlus2. Changing this settings makes it a bit louder.
